### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Vapi [Model Context Protocol](https://modelcontextprotocol.com/) server allows you to integrate with Vapi APIs through function calling.
 
+<a href="https://glama.ai/mcp/servers/@VapiAI/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@VapiAI/mcp-server/badge" alt="Vapi Server MCP server" />
+</a>
+
 ## Claude Desktop Setup
 
 1. Open `Claude Desktop` and press `CMD + ,` to go to `Settings`.


### PR DESCRIPTION
This PR adds a badge for the [Vapi MCP Server](https://glama.ai/mcp/servers/@VapiAI/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@VapiAI/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@VapiAI/mcp-server/badge" alt="Vapi Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.