### PR TITLE
Feature: Add `get_call_transcript` Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+### Enhanced
+- Improved message transformation in CallTranscriptOutput to handle optional properties
+- Enhanced type safety for message handling

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The Vapi MCP Server provides the following tools for integration:
   - Immediate or scheduled calls
   - Dynamic variable values through `assistantOverrides`
 - `get_call`: Gets details of a specific call
+- `get_call_transcript`: Gets the full transcript and conversation data of a specific call
 
 > **Note:** The `create_call` action supports scheduling calls for immediate execution or for a future time. You can also pass dynamic variables using `assistantOverrides.variableValues` to personalize assistant messages.
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -304,6 +304,21 @@ export const GetCallInputSchema = z.object({
   callId: z.string().describe('ID of the call to get'),
 });
 
+export const CallTranscriptOutputSchema = BaseResponseSchema.extend({
+  id: z.string(),
+  transcript: z.string().optional(),
+  messages: z.array(z.object({
+    role: z.string(),
+    message: z.string(),
+    time: z.number().optional(),
+    duration: z.number().optional(),
+  })).optional(),
+  recordingUrl: z.string().optional(),
+  summary: z.string().optional(),
+});
+
+export const GetCallTranscriptInputSchema = GetCallInputSchema;
+
 // ===== Phone Number Schemas =====
 
 export const GetPhoneNumberInputSchema = z.object({

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -309,7 +309,7 @@ export const CallTranscriptOutputSchema = BaseResponseSchema.extend({
   transcript: z.string().optional(),
   messages: z.array(z.object({
     role: z.string(),
-    message: z.string(),
+    message: z.string().optional(),
     time: z.number().optional(),
     duration: z.number().optional(),
   })).optional(),

--- a/src/tools/call.ts
+++ b/src/tools/call.ts
@@ -1,10 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { VapiClient, Vapi } from '@vapi-ai/server-sdk';
 
-import { CallInputSchema, GetCallInputSchema } from '../schemas/index.js';
+import { CallInputSchema, GetCallInputSchema, GetCallTranscriptInputSchema } from '../schemas/index.js';
 import {
   transformCallInput,
   transformCallOutput,
+  transformCallTranscriptOutput,
 } from '../transformers/index.js';
 import { createToolHandler } from './utils.js';
 
@@ -40,6 +41,16 @@ export const registerCallTools = (
     createToolHandler(async (data) => {
       const call = await vapiClient.calls.get(data.callId);
       return transformCallOutput(call);
+    })
+  );
+
+  server.tool(
+    'get_call_transcript',
+    'Gets the full transcript and conversation data of a specific call',
+    GetCallTranscriptInputSchema.shape,
+    createToolHandler(async (data) => {
+      const call = await vapiClient.calls.get(data.callId);
+      return transformCallTranscriptOutput(call);
     })
   );
 };

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -228,6 +228,25 @@ export function transformCallOutput(
   };
 }
 
+export function transformCallTranscriptOutput(
+  call: Vapi.Call
+): z.infer<typeof CallTranscriptOutputSchema> {
+  return {
+    id: call.id,
+    createdAt: call.createdAt,
+    updatedAt: call.updatedAt,
+    transcript: call.artifact?.transcript,
+    messages: call.artifact?.messages?.map(msg => ({
+      role: msg.role,
+      message: msg.message,
+      time: msg.time,
+      duration: msg.duration,
+    })),
+    recordingUrl: call.artifact?.recordingUrl,
+    summary: call.analysis?.summary,
+  };
+}
+
 // ===== Phone Number Transformers =====
 
 export function transformPhoneNumberOutput(


### PR DESCRIPTION
This pull request introduces a new tool, `get_call_transcript`, to the Vapi MCP server. This tool allows users to retrieve the full transcript.

The existing `get_call` tool only returns basic metadata about a call, omitting the rich conversational data that is crucial for analyzing and improving AI assistant prompts.

## Implementation
The implementation follows the existing architecture of the MCP server to ensure consistency and maintainability:

1.  **Schema Definition (`src/schemas/index.ts`):**
    *   A new `CallTranscriptOutputSchema` was created to define the shape of the detailed call data.
    *   A `GetCallTranscriptInputSchema` was added, reusing the existing `GetCallInputSchema`.

2.  **Transformer Function (`src/transformers/index.ts`):**
    *   A new `transformCallTranscriptOutput` function was implemented to map the full `Vapi.Call` object to the new schema, extracting the transcript, messages, and other details.

3.  **Tool Registration (`src/tools/call.ts`):**
    *   The `get_call_transcript` tool was registered, using the new schema and transformer. It leverages the same `vapiClient.calls.get()` method as the `get_call` tool.

4.  **Documentation (`README.md`):**
    *   The `README.md` file has been updated to include the new `get_call_transcript` tool in the "Supported Actions" section.