### PR TITLE
ci: add KYA security scan for MCP dependencies

### DIFF
--- a/.github/workflows/kya-scan.yml
+++ b/.github/workflows/kya-scan.yml
@@ -1,9 +1,13 @@
 name: KYA Security Scan
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   kya-scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Thezenmonster/kya-scan-action@v1
+      - uses: Thezenmonster/kya-scan-action@d4d86df07bacaefe57970b69db6fa7a776dfe15b
+

--- a/.github/workflows/kya-scan.yml
+++ b/.github/workflows/kya-scan.yml
@@ -1,0 +1,9 @@
+name: KYA Security Scan
+on: [push, pull_request]
+
+jobs:
+  kya-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Thezenmonster/kya-scan-action@v1


### PR DESCRIPTION
Automated MCP dependency security scanning on every push and PR via [KYA Scan](https://github.com/Thezenmonster/kya-scan-action).

**What it checks per dependency:**
- Abuse database: has this package been reported for malicious behaviour?
- Install scripts: does the package run code on npm install?
- Suspicious URLs: hardcoded IPs or exfiltration domains?
- Prompt injection: manipulation patterns in package metadata?
- Metadata quality: missing repo, licence, or description?

919 MCP packages scanned. 98.5% clean. This catches the rest before they reach your project.

Free, no API key, no configuration. One YAML file, zero code changes.

[KYA Scan Action](https://github.com/Thezenmonster/kya-scan-action) | [Scanner](https://agentscores.xyz)