### PR TITLE
feat: add get_call_details tool

### DIFF
--- a/src/__tests__/mcp-server-e2e.test.ts
+++ b/src/__tests__/mcp-server-e2e.test.ts
@@ -59,6 +59,7 @@ describe('MCP Server E2E Test', () => {
     expect(toolNames).toContain('list_calls');
     expect(toolNames).toContain('create_call');
     expect(toolNames).toContain('get_call');
+    expect(toolNames).toContain('get_call_details');
   });
 
   describe('Assistant Tools', () => {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -304,6 +304,38 @@ export const GetCallInputSchema = z.object({
   callId: z.string().describe('ID of the call to get'),
 });
 
+export const CALL_DETAIL_FIELDS = [
+  'transcript',
+  'recordingUrl',
+  'messages',
+  'costs',
+  'cost',
+  'analysis',
+  'summary',
+  'artifact',
+] as const;
+
+export const GetCallDetailsInputSchema = z.object({
+  callId: z.string().describe('ID of the call to get full details for'),
+  include: z
+    .array(z.enum(CALL_DETAIL_FIELDS))
+    .optional()
+    .describe(
+      'Subset of detail fields to return. Omit to return the full call object. Useful for keeping LLM context small on long calls.'
+    ),
+});
+
+export const CallDetailsOutputSchema = CallOutputSchema.extend({
+  transcript: z.string().optional(),
+  recordingUrl: z.string().optional(),
+  summary: z.string().optional(),
+  messages: z.array(z.any()).optional(),
+  costs: z.array(z.any()).optional(),
+  cost: z.number().optional(),
+  analysis: z.any().optional(),
+  artifact: z.any().optional(),
+});
+
 // ===== Phone Number Schemas =====
 
 export const GetPhoneNumberInputSchema = z.object({

--- a/src/tools/call.ts
+++ b/src/tools/call.ts
@@ -1,10 +1,15 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { VapiClient, Vapi } from '@vapi-ai/server-sdk';
 
-import { CallInputSchema, GetCallInputSchema } from '../schemas/index.js';
+import {
+  CallInputSchema,
+  GetCallInputSchema,
+  GetCallDetailsInputSchema,
+} from '../schemas/index.js';
 import {
   transformCallInput,
   transformCallOutput,
+  transformCallDetailsOutput,
 } from '../transformers/index.js';
 import { createToolHandler } from './utils.js';
 
@@ -40,6 +45,16 @@ export const registerCallTools = (
     createToolHandler(async (data) => {
       const call = await vapiClient.calls.get(data.callId);
       return transformCallOutput(call);
+    })
+  );
+
+  server.tool(
+    'get_call_details',
+    'Gets full details of a specific call (transcript, recording URL, messages, costs, analysis, summary, artifact). Use after get_call when summary fields are not enough. Pass `include` to scope the response and avoid blowing past LLM context windows on long calls.',
+    GetCallDetailsInputSchema.shape,
+    createToolHandler(async (data) => {
+      const call = await vapiClient.calls.get(data.callId);
+      return transformCallDetailsOutput(call, data.include);
     })
   );
 };

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -10,6 +10,7 @@ import {
   UpdateAssistantInputSchema,
   CreateToolInputSchema,
   UpdateToolInputSchema,
+  CALL_DETAIL_FIELDS,
 } from '../schemas/index.js';
 
 // ===== Assistant Transformers =====
@@ -226,6 +227,29 @@ export function transformCallOutput(
       : undefined,
     scheduledAt: call.schedulePlan?.earliestAt,
   };
+}
+
+export function transformCallDetailsOutput(
+  call: Vapi.Call,
+  include?: ReadonlyArray<(typeof CALL_DETAIL_FIELDS)[number]>
+): Record<string, unknown> {
+  const summary = transformCallOutput(call);
+  const callRecord = call as unknown as Record<string, unknown>;
+  const artifact = (callRecord.artifact ?? {}) as Record<string, unknown>;
+
+  const fields = include ?? CALL_DETAIL_FIELDS;
+  const details: Record<string, unknown> = {};
+  for (const field of fields) {
+    const value = callRecord[field] ?? artifact[field];
+    if (value !== undefined) {
+      details[field] = value;
+    }
+  }
+
+  if (include) {
+    return { id: call.id, ...details };
+  }
+  return { ...summary, ...details };
 }
 
 // ===== Phone Number Transformers =====


### PR DESCRIPTION
## Summary

The existing `get_call` tool returns a summary projection (id, status, endedReason, assistantId, phoneNumberId, customer.number, scheduledAt) — there's no way to fetch transcripts, recordings, messages, costs, or analysis through MCP without dropping out to the REST API.

This adds a sibling `get_call_details` tool that returns the full call payload. It accepts an optional `include` array so callers can scope the response to specific fields and keep LLM context windows manageable on long calls.

## Changes

- New schemas in `src/schemas/index.ts`:
  - `GetCallDetailsInputSchema` (callId + optional `include`)
  - `CallDetailsOutputSchema` (extends `CallOutputSchema`)
  - `CALL_DETAIL_FIELDS` constant
- New transformer `transformCallDetailsOutput` in `src/transformers/index.ts` — falls back to `call.artifact[field]` when the field isn't on the top-level call object
- New tool registration `get_call_details` in `src/tools/call.ts`, paired with the existing `get_call`
- E2E test updated to assert the tool is registered

## Test plan

- [x] `npm run build` passes
- [x] `tsc --noEmit` clean
- [ ] Manually verify against a real call ID via the MCP inspector
- [ ] `include: ['transcript']` returns just `{ id, transcript }`
- [ ] No `include` returns the full summary + all detail fields